### PR TITLE
Radam dependency

### DIFF
--- a/dynamic_strf/modeling.py
+++ b/dynamic_strf/modeling.py
@@ -7,7 +7,6 @@ from typing import Tuple
 
 import numpy as np
 import torch
-import radam
 import torchaudio
 import pytorch_lightning as pl
 
@@ -145,7 +144,7 @@ class BaseEncoder(pl.LightningModule):
         params = self.parameters()
         
         if isinstance(self._optimizer, dict):
-            optimizer = radam.RAdam(params, **self._optimizer)
+            optimizer = torch.optim.RAdam(params, **self._optimizer)
         else:
             optimizer = self._optimizer(params)
         

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,6 @@ setuptools.setup(
         'torch',
         'torchaudio',
         'pytorch_lightning',
-        'radam',
         'ffmpeg-python',
         'matplotlib'
     ],


### PR DESCRIPTION
radam is no longer a package on pypi, so it can't be installed as a new dependency. However, it is now implemented in pytorch natively, so this PR switches from using the old radam to the torch.optim.RAdam instead.